### PR TITLE
Accept repo urls that don't have '.git' extension

### DIFF
--- a/bin/prfetch
+++ b/bin/prfetch
@@ -8,9 +8,9 @@ remote_name = ARGV[1] || 'origin'
 
 git = Git.open('./')
 remote = git.remotes.select { |r| r.name == remote_name }.first
-repo = if (match = remote.url.match(%r{^git@[^:]+:(?<repo>.+)\.git}))
+repo = if (match = remote.url.match(%r{^git@[^:]+:(?<repo>.+)(?:\.git)?$}))
           match['repo']
-        elsif (match = remote.url.match(%r{^https://[^/]+/(?<repo>.+)\.git}))
+        elsif (match = remote.url.match(%r{^https://[^/]+/(?<repo>.+)(?:\.git)?$}))
           match['repo']
         end
 exit 1 unless repo


### PR DESCRIPTION
Remote urls may not have `.git` extension.
